### PR TITLE
Dev

### DIFF
--- a/DTXMania/Core/CSkin.cs
+++ b/DTXMania/Core/CSkin.cs
@@ -787,11 +787,11 @@ internal class CSkin : IDisposable
 	}
 
 
-	public void tRemoveMixerAll()
+	public void tRemoveMixerAll(CSystemSound? keepPlaying = null)
 	{
 		for (int i = 0; i < nSystemSoundCount; i++)
 		{
-			if (this[i] != null && this[i].b読み込み成功)
+			if (this[i] != null && this[i] != keepPlaying && this[i].b読み込み成功)
 			{
 				this[i].tStop();
 				this[i].tRemoveMixer();

--- a/DTXMania/Core/Config/CConfigIni.Schema.cs
+++ b/DTXMania/Core/Config/CConfigIni.Schema.cs
@@ -235,9 +235,9 @@ internal partial class CConfigIni
 				Bool("FillInEffect", c => c.bFillInEnabled)),
 			G("フィルイン達成時の歓声の再生(0:OFF, 1:ON)",
 				Bool("AudienceSound", c => c.b歓声を発声する)),
-			G("曲選択からプレビュー音の再生までのウェイト[ms]",
+			G(["曲選択でプレビュー音が鳴り始めるまでの待ち時間[ms]。", "Delay (ms) before the preview sound starts in song select."],
 				Int("PreviewSoundWait", 0, 0x5f5e0ff, c => c.nSongSelectSoundPreviewWaitTimeMs)),
-			G("曲選択からプレビュー画像表示までのウェイト[ms]",
+			G(["曲選択でプレビュー画像が表示されるまでの待ち時間[ms]。", "Delay (ms) before the preview image shows in song select."],
 				Int("PreviewImageWait", 0, 0x5f5e0ff, c => c.nSongSelectImagePreviewWaitTimeMs)),
 			G("Waveの再生位置自動補正(0:OFF, 1:ON)",
 				Bool("AdjustWaves", c => c.bWave再生位置自動調整機能有効)),
@@ -393,10 +393,10 @@ internal partial class CConfigIni
 			G("演奏速度(5～40)(→x5/20～x40/20)",
 				Int("PlaySpeed", CConstants.PLAYSPEED_MIN, CConstants.PLAYSPEED_MAX, c => c.nPlaySpeed)),
 			G([
-					"曲クリア後、リザルト画面に移行するまでの待ち時間(ms)。",
-					"Delay in milliseconds after clearing a song before the result screen appears."
+					"リザルト画面が表示されるまでの待ち時間[ms]。",
+					"Delay (ms) before the results screen is shown."
 				],
-				Int("StageClearWait", 0, 5000, c => c.nStageClearWaitMs)),
+				Int("ResultDelay", 0, 5000, c => c.nResultDelayMs)),
 			G([
 					"読み込み画面を表示する最小時間[ms]。",
 					"Minimum time (ms) the loading screen is shown."

--- a/DTXMania/Core/Config/CConfigIni.Schema.cs
+++ b/DTXMania/Core/Config/CConfigIni.Schema.cs
@@ -392,6 +392,11 @@ internal partial class CConfigIni
 				Int("BassScrollSpeed", 0, 0x7cf, c => c.nScrollSpeed.Bass)),
 			G("演奏速度(5～40)(→x5/20～x40/20)",
 				Int("PlaySpeed", CConstants.PLAYSPEED_MIN, CConstants.PLAYSPEED_MAX, c => c.nPlaySpeed)),
+			G([
+					"曲クリア後、リザルト画面に移行するまでの待ち時間(ms)。",
+					"Delay in milliseconds after clearing a song before the result screen appears."
+				],
+				Int("StageClearWait", 0, 5000, c => c.nStageClearWaitMs)),
 			G("Save score when PlaySpeed is not 100% (0:OFF, 1:ON)",
 				Bool("SaveScoreIfModifiedPlaySpeed", c => c.bSaveScoreIfModifiedPlaySpeed)),
 			G("グラフ表示(0:OFF, 1:ON)",

--- a/DTXMania/Core/Config/CConfigIni.Schema.cs
+++ b/DTXMania/Core/Config/CConfigIni.Schema.cs
@@ -397,6 +397,11 @@ internal partial class CConfigIni
 					"Delay in milliseconds after clearing a song before the result screen appears."
 				],
 				Int("StageClearWait", 0, 5000, c => c.nStageClearWaitMs)),
+			G([
+					"読み込み画面を表示する最小時間[ms]。",
+					"Minimum time (ms) the loading screen is shown."
+				],
+				Int("LoadingMinDuration", 0, 10000, c => c.nLoadingMinMs)),
 			G("Save score when PlaySpeed is not 100% (0:OFF, 1:ON)",
 				Bool("SaveScoreIfModifiedPlaySpeed", c => c.bSaveScoreIfModifiedPlaySpeed)),
 			G("グラフ表示(0:OFF, 1:ON)",

--- a/DTXMania/Core/Config/CConfigIni.cs
+++ b/DTXMania/Core/Config/CConfigIni.cs
@@ -643,8 +643,8 @@ internal partial class CConfigIni
 		nPedalLagTime = 0;
 
 		bAutoAddGage = false;
-		nSongSelectSoundPreviewWaitTimeMs = 50;
-		nSongSelectImagePreviewWaitTimeMs = 0;
+		nSongSelectSoundPreviewWaitTimeMs = 200;
+		nSongSelectImagePreviewWaitTimeMs = 200;
 		bWave再生位置自動調整機能有効 = true;
 		bBGM音を発声する = true;
 		bドラム打音を発声する = true;

--- a/DTXMania/Core/Config/CConfigIni.cs
+++ b/DTXMania/Core/Config/CConfigIni.cs
@@ -387,7 +387,7 @@ internal partial class CConfigIni
 		}
 	}
 	public int nRisky;						// #23559 2011.6.20 yyagi Riskyでの残ミス数。0で閉店
-	public int nStageClearWaitMs;			// How long to hold on a cleared chart before the result screen (ms).
+	public int nResultDelayMs;				// Delay after clearing a song before the result screen is shown (ms).
 	public int nLoadingMinMs;				// Minimum time the song-loading screen stays up, even on a fast load (ms).
 	public bool bIsAllowedDoubleClickFullscreen;	// #26752 2011.11.27 yyagi ダブルクリックしてもフルスクリーンに移行しない
 	public bool bIsSwappedGuitarBass			// #24063 2011.1.16 yyagi ギターとベースの切り替え中か否か
@@ -768,7 +768,7 @@ internal partial class CConfigIni
 
 		bHAZARD = false;
 		nRisky = 0;							// #23539 2011.7.26 yyagi RISKYモード
-		nStageClearWaitMs = 2000;			// original NX pacing (~2s hold before result)
+		nResultDelayMs = 2000;				// original NX pacing (~2s before the result screen)
 		nLoadingMinMs = 1500;				// keep the loading screen up at least this long
 		nShowLagType = (int) EShowLagType.OFF;	// #25370 2011.6.3 yyagi ズレ時間表示
 		nShowLagTypeColor = 0;

--- a/DTXMania/Core/Config/CConfigIni.cs
+++ b/DTXMania/Core/Config/CConfigIni.cs
@@ -388,6 +388,7 @@ internal partial class CConfigIni
 	}
 	public int nRisky;						// #23559 2011.6.20 yyagi Riskyでの残ミス数。0で閉店
 	public int nStageClearWaitMs;			// How long to hold on a cleared chart before the result screen (ms).
+	public int nLoadingMinMs;				// Minimum time the song-loading screen stays up, even on a fast load (ms).
 	public bool bIsAllowedDoubleClickFullscreen;	// #26752 2011.11.27 yyagi ダブルクリックしてもフルスクリーンに移行しない
 	public bool bIsSwappedGuitarBass			// #24063 2011.1.16 yyagi ギターとベースの切り替え中か否か
 	{
@@ -768,6 +769,7 @@ internal partial class CConfigIni
 		bHAZARD = false;
 		nRisky = 0;							// #23539 2011.7.26 yyagi RISKYモード
 		nStageClearWaitMs = 2000;			// original NX pacing (~2s hold before result)
+		nLoadingMinMs = 1500;				// keep the loading screen up at least this long
 		nShowLagType = (int) EShowLagType.OFF;	// #25370 2011.6.3 yyagi ズレ時間表示
 		nShowLagTypeColor = 0;
 		bShowLagHitCount = false;

--- a/DTXMania/Core/Config/CConfigIni.cs
+++ b/DTXMania/Core/Config/CConfigIni.cs
@@ -387,6 +387,7 @@ internal partial class CConfigIni
 		}
 	}
 	public int nRisky;						// #23559 2011.6.20 yyagi Riskyでの残ミス数。0で閉店
+	public int nStageClearWaitMs;			// How long to hold on a cleared chart before the result screen (ms).
 	public bool bIsAllowedDoubleClickFullscreen;	// #26752 2011.11.27 yyagi ダブルクリックしてもフルスクリーンに移行しない
 	public bool bIsSwappedGuitarBass			// #24063 2011.1.16 yyagi ギターとベースの切り替え中か否か
 	{
@@ -766,6 +767,7 @@ internal partial class CConfigIni
 
 		bHAZARD = false;
 		nRisky = 0;							// #23539 2011.7.26 yyagi RISKYモード
+		nStageClearWaitMs = 2000;			// original NX pacing (~2s hold before result)
 		nShowLagType = (int) EShowLagType.OFF;	// #25370 2011.6.3 yyagi ズレ時間表示
 		nShowLagTypeColor = 0;
 		bShowLagHitCount = false;

--- a/DTXMania/Core/Config/CConfigIni.cs
+++ b/DTXMania/Core/Config/CConfigIni.cs
@@ -769,7 +769,7 @@ internal partial class CConfigIni
 		bHAZARD = false;
 		nRisky = 0;							// #23539 2011.7.26 yyagi RISKYモード
 		nResultDelayMs = 2000;				// original NX pacing (~2s before the result screen)
-		nLoadingMinMs = 1500;				// keep the loading screen up at least this long
+		nLoadingMinMs = 1000;				// keep the loading screen up at least this long
 		nShowLagType = (int) EShowLagType.OFF;	// #25370 2011.6.3 yyagi ズレ時間表示
 		nShowLagTypeColor = 0;
 		bShowLagHitCount = false;

--- a/DTXMania/Stage/03.Config/CStageConfig.cs
+++ b/DTXMania/Stage/03.Config/CStageConfig.cs
@@ -369,7 +369,8 @@ internal class CStageConfig : CStage
         {
             keyAssignPanel.Confirm();
         }
-        else if (CDTXMania.InputManager.Keyboard.bKeyPressed(SlimDXKey.Delete))
+        else if (CDTXMania.InputManager.Keyboard.bKeyPressed(SlimDXKey.Delete)
+                 || CDTXMania.InputManager.Keyboard.bKeyPressed(SlimDXKey.Backspace))
         {
             keyAssignPanel.DeleteCurrent();
         }

--- a/DTXMania/Stage/03.Config/CStageConfig.cs
+++ b/DTXMania/Stage/03.Config/CStageConfig.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using DTXMania.Core;
 using DTXMania.UI.Config;
 using DTXMania.UI.Drawable;
+using DTXMania.UI.Item;
 using FDK;
 using SlimDXKey = SlimDX.DirectInput.Key;
 
@@ -70,9 +71,24 @@ internal class CStageConfig : CStage
         keyAssignPanel.position = new Vector3(450, 120, 0);
         keyAssignPanel.renderOrder = 42;
         keyAssignPanel.onClose = CloseKeyAssign;
+        keyAssignPanel.onNext = KeyAssignNext;
         keyAssignPanel.isVisible = false;
-        
+
+        inputTestPanel = ui.AddChild(new InputTestPanel());
+        inputTestPanel.position = new Vector3(450, 120, 0);
+        inputTestPanel.renderOrder = 42;
+        inputTestPanel.onClose = CloseKeyAssign;
+        inputTestPanel.isVisible = false;
+
+        midiTestPanel = ui.AddChild(new MidiTestPanel());
+        midiTestPanel.position = new Vector3(450, 120, 0);
+        midiTestPanel.renderOrder = 42;
+        midiTestPanel.onClose = CloseKeyAssign;
+        midiTestPanel.isVisible = false;
+
         configList.onOpenKeyAssign = OpenKeyAssign;
+        configList.onOpenInputTest = OpenInputTest;
+        configList.onOpenMidiTest = OpenMidiTest;
         
         configLeftOptionsMenu.AddSelectableChild(new UIBasicButton(20, "System", configMenu.OpenSystem));
         configLeftOptionsMenu.AddSelectableChild(new UIBasicButton(20, "Drums", configMenu.OpenDrums));
@@ -197,6 +213,8 @@ internal class CStageConfig : CStage
     private ConfigDescriptionPanel descriptionPanel;
     private ConfigMenu configMenu;
     private KeyAssignPanel keyAssignPanel; //key-assign editor overlay (opened from a pad-list row)
+    private InputTestPanel inputTestPanel;  //all-channel input-test overview (opened from an "Input Test" row)
+    private MidiTestPanel midiTestPanel;    //MIDI diagnostics feed (opened from the drums "MIDI Test" row)
 
     private const int MenuExitIndex = 4;
 
@@ -232,6 +250,19 @@ internal class CStageConfig : CStage
         if (keyAssignPanel.IsOpen)
         {
             HandleKeyAssignInput();
+            return;
+        }
+
+        if (inputTestPanel.IsOpen)
+        {
+            inputTestPanel.UpdatePreview();
+            inputTestPanel.PollClose();
+            return;
+        }
+        if (midiTestPanel.IsOpen)
+        {
+            midiTestPanel.UpdatePreview();
+            midiTestPanel.PollClose();
             return;
         }
 
@@ -275,8 +306,8 @@ internal class CStageConfig : CStage
             CDTXMania.Input.Navigate(configList.MoveUp, configList.MoveDown, configList.MoveUpDrums, configList.MoveDownDrums);
         }
 
-        //the description panel only shows once a page is focused and fully aligned
-        bool showDescription = !bFocusIsOnMenu && configList.IsSettled && !keyAssignPanel.IsOpen;
+        bool showDescription = !bFocusIsOnMenu && configList.IsSettled
+                               && !keyAssignPanel.IsOpen && !inputTestPanel.IsOpen && !midiTestPanel.IsOpen;
         descriptionPanel.Update(configList.CurrentItem, showDescription);
     }
 
@@ -289,16 +320,41 @@ internal class CStageConfig : CStage
         keyAssignPanel.Open(part, pad, padName);
     }
 
-    //returns from the editor to the pad list it was opened from
+    private void OpenInputTest((EKeyConfigPart, EKeyConfigPad, string)[] pads)
+    {
+        configList.isVisible = false;
+        configList.SetFocused(false);
+        descriptionPanel.Update(null, false);
+        inputTestPanel.Open(pads);
+    }
+
+    private void OpenMidiTest()
+    {
+        configList.isVisible = false;
+        configList.SetFocused(false);
+        descriptionPanel.Update(null, false);
+        midiTestPanel.Open();
+    }
+
     private void CloseKeyAssign()
     {
         configList.isVisible = true;
         bFocusIsOnMenu = false; //focus stays on the (pad list) page, not the left menu
     }
 
+    private void KeyAssignNext()
+    {
+        CItemBase? next = configList.SelectNextNormal();
+        if (next is { ePanelType: CItemBase.EPanelType.Normal })
+        {
+            next.RunAction(); // the pad row's action re-opens the panel for that pad
+        }
+    }
+
     private void HandleKeyAssignInput()
     {
         keyAssignPanel.PollCapture();
+        keyAssignPanel.UpdatePreview();
 
         if (keyAssignPanel.IsWaiting)
         {

--- a/DTXMania/Stage/03.Config/ConfigMenu/ConfigPage.cs
+++ b/DTXMania/Stage/03.Config/ConfigMenu/ConfigPage.cs
@@ -68,6 +68,14 @@ internal abstract class ConfigPage
         return item;
     }
 
+    protected static CItemInteger SecondsDelay(string name, int msMin, int msMax, string jp, string en, Func<int> getMs, Action<int> setMs)
+    {
+        CItemInteger item = new(name, msMin / 100, msMax / 100, getMs() / 100, jp, en);
+        item.BindConfig(() => item.nCurrentValue = getMs() / 100, () => setMs(item.nCurrentValue * 100));
+        item.formatValue = () => (item.nCurrentValue / 10.0).ToString("0.0") + "s";
+        return item;
+    }
+
     protected static CItemList Choice(string name, string jp, string en, string[] values, Func<int> get, Action<int> set)
     {
         CItemList item = new(name, CItemBase.EPanelType.Normal, get(), jp, en, values);

--- a/DTXMania/Stage/03.Config/ConfigMenu/KeyAssignPage.cs
+++ b/DTXMania/Stage/03.Config/ConfigMenu/KeyAssignPage.cs
@@ -7,15 +7,34 @@ namespace DTXMania;
 internal sealed class KeyAssignPage : ConfigPage
 {
     private readonly (EKeyConfigPart part, EKeyConfigPad pad, string label)[] pads;
+    private readonly bool includeMidiTest;
 
-    private KeyAssignPage(ConfigList list, (EKeyConfigPart, EKeyConfigPad, string)[] pads) : base(list)
+    private KeyAssignPage(ConfigList list, (EKeyConfigPart, EKeyConfigPad, string)[] pads, bool includeMidiTest = false) : base(list)
     {
         this.pads = pads;
+        this.includeMidiTest = includeMidiTest;
     }
 
     public override List<CItemBase> Build()
     {
         List<CItemBase> items = [BackItem()];
+
+        items.Add(new CItemBase(CDTXMania.isJapanese ? "入力テスト" : "Input Test", CItemBase.EPanelType.Folder,
+            "全チャンネルの入力をまとめてテストします。",
+            "Test the inputs for every channel at once.")
+        {
+            action = () => list.onOpenInputTest?.Invoke(pads)
+        });
+
+        if (includeMidiTest)
+        {
+            items.Add(new CItemBase(CDTXMania.isJapanese ? "MIDI テスト" : "MIDI Test", CItemBase.EPanelType.Folder,
+                "MIDI入力を確認します（割り当て済み/未割り当て）。",
+                "Watch incoming MIDI and see which notes are mapped.")
+            {
+                action = () => list.onOpenMidiTest?.Invoke()
+            });
+        }
 
         foreach ((EKeyConfigPart part, EKeyConfigPad pad, string label) in pads)
         {
@@ -50,7 +69,7 @@ internal sealed class KeyAssignPage : ConfigPage
         return CDTXMania.isJapanese ? $"現在: {mapping}" : $"Current: {mapping}";
     }
     
-    public static KeyAssignPage ForDrums(ConfigList list) => new(list, DrumsPads);
+    public static KeyAssignPage ForDrums(ConfigList list) => new(list, DrumsPads, includeMidiTest: true);
     public static KeyAssignPage ForGuitar(ConfigList list) => new(list, InstrumentPads(EKeyConfigPart.GUITAR));
     public static KeyAssignPage ForBass(ConfigList list) => new(list, InstrumentPads(EKeyConfigPart.BASS));
     public static KeyAssignPage ForSystem(ConfigList list) => new(list, SystemPads);

--- a/DTXMania/Stage/03.Config/ConfigMenu/KeyAssignPage.cs
+++ b/DTXMania/Stage/03.Config/ConfigMenu/KeyAssignPage.cs
@@ -20,8 +20,8 @@ internal sealed class KeyAssignPage : ConfigPage
         List<CItemBase> items = [BackItem()];
 
         items.Add(new CItemBase(CDTXMania.isJapanese ? "入力テスト" : "Input Test", CItemBase.EPanelType.Folder,
-            "全チャンネルの入力をまとめてテストします。",
-            "Test the inputs for every channel at once.")
+            "現在割り当てられている入力をテストします。",
+            "Test your currently mapped inputs.")
         {
             action = () => list.onOpenInputTest?.Invoke(pads)
         });
@@ -29,8 +29,8 @@ internal sealed class KeyAssignPage : ConfigPage
         if (includeMidiTest)
         {
             items.Add(new CItemBase(CDTXMania.isJapanese ? "MIDI テスト" : "MIDI Test", CItemBase.EPanelType.Folder,
-                "MIDI入力を確認します（割り当て済み/未割り当て）。",
-                "Watch incoming MIDI and see which notes are mapped.")
+                "未割り当てのMIDI入力がないか確認できます。",
+                "Check for any MIDI inputs that aren't mapped.")
             {
                 action = () => list.onOpenMidiTest?.Invoke()
             });

--- a/DTXMania/Stage/03.Config/ConfigMenu/System/GameplayConfigPage.cs
+++ b/DTXMania/Stage/03.Config/ConfigMenu/System/GameplayConfigPage.cs
@@ -41,15 +41,6 @@ internal sealed class GameplayConfigPage : ConfigPage
         playSpeed.formatValue = () => (playSpeed.nCurrentValue / 20.0).ToString("0.000");
         items.Add(playSpeed);
 
-        CItemInteger clearDelay = new("ClearDelay", 0, 50, CDTXMania.ConfigIni.nStageClearWaitMs / 100,
-            "曲をクリアしてからリザルト画面に\n移行するまでの待ち時間です。\n0.1秒単位で設定できます。",
-            "How long to hold on the cleared chart before\nthe result screen appears.\nAdjustable in 0.1s steps.");
-        clearDelay.BindConfig(
-            () => clearDelay.nCurrentValue = CDTXMania.ConfigIni.nStageClearWaitMs / 100,
-            () => CDTXMania.ConfigIni.nStageClearWaitMs = clearDelay.nCurrentValue * 100);
-        clearDelay.formatValue = () => (clearDelay.nCurrentValue / 10.0).ToString("0.0") + "s";
-        items.Add(clearDelay);
-
         CItemList skillMode = new("SkillMode", CItemBase.EPanelType.Normal, CDTXMania.ConfigIni.nSkillMode,
             "達成率、スコアの計算方法を変更します。\nCLASSIC:V6までのスコア計算とV8までの\nランク計算です。\nXG:XGシリーズの達成率計算とV7以降の\nスコア計算です。",
             "Skill rate and score calculation method\nCLASSIC: Pre-V6 score calculation and pre-V8 rank calculation\nXG: Current score and rank calculation",

--- a/DTXMania/Stage/03.Config/ConfigMenu/System/GameplayConfigPage.cs
+++ b/DTXMania/Stage/03.Config/ConfigMenu/System/GameplayConfigPage.cs
@@ -41,6 +41,15 @@ internal sealed class GameplayConfigPage : ConfigPage
         playSpeed.formatValue = () => (playSpeed.nCurrentValue / 20.0).ToString("0.000");
         items.Add(playSpeed);
 
+        CItemInteger clearDelay = new("ClearDelay", 0, 50, CDTXMania.ConfigIni.nStageClearWaitMs / 100,
+            "曲をクリアしてからリザルト画面に\n移行するまでの待ち時間です。\n0.1秒単位で設定できます。",
+            "How long to hold on the cleared chart before\nthe result screen appears.\nAdjustable in 0.1s steps.");
+        clearDelay.BindConfig(
+            () => clearDelay.nCurrentValue = CDTXMania.ConfigIni.nStageClearWaitMs / 100,
+            () => CDTXMania.ConfigIni.nStageClearWaitMs = clearDelay.nCurrentValue * 100);
+        clearDelay.formatValue = () => (clearDelay.nCurrentValue / 10.0).ToString("0.0") + "s";
+        items.Add(clearDelay);
+
         CItemList skillMode = new("SkillMode", CItemBase.EPanelType.Normal, CDTXMania.ConfigIni.nSkillMode,
             "達成率、スコアの計算方法を変更します。\nCLASSIC:V6までのスコア計算とV8までの\nランク計算です。\nXG:XGシリーズの達成率計算とV7以降の\nスコア計算です。",
             "Skill rate and score calculation method\nCLASSIC: Pre-V6 score calculation and pre-V8 rank calculation\nXG: Current score and rank calculation",

--- a/DTXMania/Stage/03.Config/ConfigMenu/System/MenuConfigPage.cs
+++ b/DTXMania/Stage/03.Config/ConfigMenu/System/MenuConfigPage.cs
@@ -40,21 +40,29 @@ internal sealed class MenuConfigPage : ConfigPage
             () => CDTXMania.ConfigIni.bランダムセレクトで子BOXを検索対象とする = randomFromSubBox.bON);
         items.Add(randomFromSubBox);
 
-        CItemInteger previewSoundWait = new("PreSoundWait", 0, 0x2710, CDTXMania.ConfigIni.nSongSelectSoundPreviewWaitTimeMs,
-            "カーソルが合わされてから\nプレビュー音が鳴り始める\nまでの時間を指定します。\n0～10000[ms]が指定可能です。",
-            "Delay time (ms) to start playing preview sound in song selection screen.\nYou can specify from 0ms to 10000ms.");
-        previewSoundWait.BindConfig(
-            () => previewSoundWait.nCurrentValue = CDTXMania.ConfigIni.nSongSelectSoundPreviewWaitTimeMs,
-            () => CDTXMania.ConfigIni.nSongSelectSoundPreviewWaitTimeMs = previewSoundWait.nCurrentValue);
-        items.Add(previewSoundWait);
+        items.Add(SecondsDelay("PreSoundWait", 0, 10000,
+            "カーソルが合わされてから\nプレビュー音が鳴り始めるまでの待ち時間。",
+            "Delay before the preview sound starts in song select.",
+            () => CDTXMania.ConfigIni.nSongSelectSoundPreviewWaitTimeMs,
+            v => CDTXMania.ConfigIni.nSongSelectSoundPreviewWaitTimeMs = v));
 
-        CItemInteger previewImageWait = new("PreImageWait", 0, 0x2710, CDTXMania.ConfigIni.nSongSelectImagePreviewWaitTimeMs,
-            "カーソルが合わされてから\nプレビュー画像が表示\nされるまでの時間を\n指定します。\n0～10000[ms]が指定可能です。",
-            "Delay time (ms) to show preview image in song selection screen.\nYou can specify from 0ms to 10000ms.");
-        previewImageWait.BindConfig(
-            () => previewImageWait.nCurrentValue = CDTXMania.ConfigIni.nSongSelectImagePreviewWaitTimeMs,
-            () => CDTXMania.ConfigIni.nSongSelectImagePreviewWaitTimeMs = previewImageWait.nCurrentValue);
-        items.Add(previewImageWait);
+        items.Add(SecondsDelay("PreImageWait", 0, 10000,
+            "カーソルが合わされてから\nプレビュー画像が表示されるまでの待ち時間。",
+            "Delay before the preview image shows in song select.",
+            () => CDTXMania.ConfigIni.nSongSelectImagePreviewWaitTimeMs,
+            v => CDTXMania.ConfigIni.nSongSelectImagePreviewWaitTimeMs = v));
+
+        items.Add(SecondsDelay("ResultDelay", 0, 5000,
+            "リザルト画面が表示されるまでの待ち時間。",
+            "Delay before the results screen is shown.",
+            () => CDTXMania.ConfigIni.nResultDelayMs,
+            v => CDTXMania.ConfigIni.nResultDelayMs = v));
+
+        items.Add(SecondsDelay("LoadDelay", 0, 10000,
+            "読み込み画面を表示する最小時間。",
+            "Minimum time the loading screen is shown.",
+            () => CDTXMania.ConfigIni.nLoadingMinMs,
+            v => CDTXMania.ConfigIni.nLoadingMinMs = v));
 
         items.Add(BackItem());
         return items;

--- a/DTXMania/Stage/05.SongLoading/CStageSongLoading.cs
+++ b/DTXMania/Stage/05.SongLoading/CStageSongLoading.cs
@@ -376,6 +376,9 @@ internal class CStageSongLoading : CStage
         CDTXMania.Skin.soundNowLoading.tPlay();
         ePhaseID = EPhase.Common_FadeIn;
 
+        bBmpAviLoaded = false;
+        ctLoadingMinDelay = new CCounter(0, CDTXMania.ConfigIni.nLoadingMinMs, 1, CDTXMania.Timer);
+
         try
         {
             string path = cdtx.strFolderName + cdtx.PREIMAGE;
@@ -430,22 +433,33 @@ internal class CStageSongLoading : CStage
 
         if (loadingTask.IsCompleted)
         {
-            Trace.TraceInformation("Main load finished, loading BMP / AVI on the main thread now");
-            
-            DateTime timeBeginLoadBMPAVI = DateTime.Now;
-            if (CDTXMania.ConfigIni.bBGAEnabled)
-                CDTXMania.DTX.tLoadBMP_BMPTEX();
+            if (!bBmpAviLoaded)
+            {
+                Trace.TraceInformation("Main load finished, loading BMP / AVI on the main thread now");
 
-            //load BPM and AVI on main thread because :(
-            if (CDTXMania.ConfigIni.bAVIEnabled)
-                CDTXMania.DTX.tLoadAVI();
-            var span = DateTime.Now - timeBeginLoadBMPAVI;
-            Trace.TraceInformation("Time to load BMP / AVI ({0,4}): {1}",
-                (CDTXMania.DTX.listBMP.Count + CDTXMania.DTX.listBMPTEX.Count + CDTXMania.DTX.listAVI.Count),
-                span.ToString());
-            
-            CDTXMania.nStageNumber++;
-            return (int)ESongLoadingScreenReturnValue.LoadingComplete;
+                DateTime timeBeginLoadBMPAVI = DateTime.Now;
+                if (CDTXMania.ConfigIni.bBGAEnabled)
+                    CDTXMania.DTX.tLoadBMP_BMPTEX();
+
+                //load BPM and AVI on main thread because :(
+                if (CDTXMania.ConfigIni.bAVIEnabled)
+                    CDTXMania.DTX.tLoadAVI();
+                var span = DateTime.Now - timeBeginLoadBMPAVI;
+                Trace.TraceInformation("Time to load BMP / AVI ({0,4}): {1}",
+                    (CDTXMania.DTX.listBMP.Count + CDTXMania.DTX.listBMPTEX.Count + CDTXMania.DTX.listAVI.Count),
+                    span.ToString());
+
+                bBmpAviLoaded = true;
+            }
+
+            ctLoadingMinDelay?.tUpdate();
+            bool minElapsed = ctLoadingMinDelay == null || ctLoadingMinDelay.bReachedEndValue;
+
+            if (minElapsed)
+            {
+                CDTXMania.nStageNumber++;
+                return (int)ESongLoadingScreenReturnValue.LoadingComplete;
+            }
         }
 
         return (int)ESongLoadingScreenReturnValue.Continue;
@@ -870,6 +884,8 @@ internal class CStageSongLoading : CStage
     private Task? loadingTask;
     private CancellationTokenSource? loadingCancellationTokenSource;
     private bool bCancelRequested;
+    private CCounter? ctLoadingMinDelay; // keeps the loading screen up for at least nLoadingMinMs
+    private bool bBmpAviLoaded;          // guards the one-time main-thread BMP/AVI load
     
     private string strSongTitle;
     private string strArtistName;

--- a/DTXMania/Stage/06.Performance/CStagePerfCommonScreen.cs
+++ b/DTXMania/Stage/06.Performance/CStagePerfCommonScreen.cs
@@ -789,7 +789,7 @@ internal abstract class CStagePerfCommonScreen : CStage
     protected STDGBVALUE<CCounter> ctChipPatternAnimation;
     protected abstract void tJudgeLineMovingUpandDown();
     protected EPerfScreenReturnValue eReturnValueAfterFadeOut;
-    protected CCounter ctStageClearDelay;
+    protected CCounter ctResultDelay;
     protected readonly EChannel[,] nBGAスコープチャンネルマップ = new[,] { { EChannel.BGALayer1_Swap, EChannel.BGALayer2_Swap, EChannel.BGALayer3_Swap, EChannel.BGALayer4_Swap, EChannel.BGALayer5_Swap, EChannel.BGALayer6_Swap, EChannel.BGALayer7_Swap, EChannel.BGALayer8_Swap }, { EChannel.BGALayer1, EChannel.BGALayer2, EChannel.BGALayer3, EChannel.BGALayer4, EChannel.BGALayer5, EChannel.BGALayer6, EChannel.BGALayer7, EChannel.BGALayer8 } };
     protected readonly int[] nチャンネル0Atoパッド08 = [1, 2, 3, 4, 5, 7, 6, 1, 8, 0, 9, 9];
     protected readonly int[] nチャンネル0Atoレーン07 = [1, 2, 3, 4, 5, 7, 6, 1, 9, 0, 8, 8];
@@ -3873,16 +3873,16 @@ internal abstract class CStagePerfCommonScreen : CStage
                 break;
 
             case EPhase.PERFORMANCE_STAGE_CLEAR:
-                ctStageClearDelay?.tUpdate();
-                return ctStageClearDelay == null || ctStageClearDelay.bReachedEndValue;
+                ctResultDelay?.tUpdate();
+                return ctResultDelay == null || ctResultDelay.bReachedEndValue;
 
         }
         return false;
     }
 
-    protected void tStartStageClearDelay()
+    protected void tStartResultDelay()
     {
-        ctStageClearDelay = new CCounter(0, CDTXMania.ConfigIni.nStageClearWaitMs, 1, CDTXMania.Timer);
+        ctResultDelay = new CCounter(0, CDTXMania.ConfigIni.nResultDelayMs, 1, CDTXMania.Timer);
     }
     protected void tUpdateAndDraw_LaneFlushD()
     {

--- a/DTXMania/Stage/06.Performance/CStagePerfCommonScreen.cs
+++ b/DTXMania/Stage/06.Performance/CStagePerfCommonScreen.cs
@@ -788,6 +788,7 @@ internal abstract class CStagePerfCommonScreen : CStage
     protected STDGBVALUE<CCounter> ctChipPatternAnimation;
     protected abstract void tJudgeLineMovingUpandDown();
     protected EPerfScreenReturnValue eReturnValueAfterFadeOut;
+    protected CCounter ctStageClearDelay;
     protected readonly EChannel[,] nBGAスコープチャンネルマップ = new[,] { { EChannel.BGALayer1_Swap, EChannel.BGALayer2_Swap, EChannel.BGALayer3_Swap, EChannel.BGALayer4_Swap, EChannel.BGALayer5_Swap, EChannel.BGALayer6_Swap, EChannel.BGALayer7_Swap, EChannel.BGALayer8_Swap }, { EChannel.BGALayer1, EChannel.BGALayer2, EChannel.BGALayer3, EChannel.BGALayer4, EChannel.BGALayer5, EChannel.BGALayer6, EChannel.BGALayer7, EChannel.BGALayer8 } };
     protected readonly int[] nチャンネル0Atoパッド08 = [1, 2, 3, 4, 5, 7, 6, 1, 8, 0, 9, 9];
     protected readonly int[] nチャンネル0Atoレーン07 = [1, 2, 3, 4, 5, 7, 6, 1, 9, 0, 8, 8];
@@ -3871,10 +3872,16 @@ internal abstract class CStagePerfCommonScreen : CStage
                 break;
 
             case EPhase.PERFORMANCE_STAGE_CLEAR:
-                return true;
+                ctStageClearDelay?.tUpdate();
+                return ctStageClearDelay == null || ctStageClearDelay.bReachedEndValue;
 
         }
         return false;
+    }
+
+    protected void tStartStageClearDelay()
+    {
+        ctStageClearDelay = new CCounter(0, CDTXMania.ConfigIni.nStageClearWaitMs, 1, CDTXMania.Timer);
     }
     protected void tUpdateAndDraw_LaneFlushD()
     {

--- a/DTXMania/Stage/06.Performance/CStagePerfCommonScreen.cs
+++ b/DTXMania/Stage/06.Performance/CStagePerfCommonScreen.cs
@@ -403,7 +403,8 @@ internal abstract class CStagePerfCommonScreen : CStage
 
         nPolyphonicSounds = CDTXMania.ConfigIni.nPoliphonicSounds;
 
-        CDTXMania.Skin.tRemoveMixerAll();	// 効果音のストリームをミキサーから解除しておく
+        //let the loading sound gracefully fade out
+        CDTXMania.Skin.tRemoveMixerAll(CDTXMania.Skin.soundNowLoading);
 
         //lockmixer = new object();
         queueMixerSound = new Queue<stmixer>(64);

--- a/DTXMania/Stage/06.Performance/DrumsScreen/CStagePerfDrumsScreen.cs
+++ b/DTXMania/Stage/06.Performance/DrumsScreen/CStagePerfDrumsScreen.cs
@@ -277,7 +277,7 @@ internal class CStagePerfDrumsScreen : CStagePerfCommonScreen
             {
                 eReturnValueAfterFadeOut = EPerfScreenReturnValue.StageClear;
                 ePhaseID = EPhase.PERFORMANCE_STAGE_CLEAR;
-                tStartStageClearDelay();
+                tStartResultDelay();
             }
         }
 

--- a/DTXMania/Stage/06.Performance/DrumsScreen/CStagePerfDrumsScreen.cs
+++ b/DTXMania/Stage/06.Performance/DrumsScreen/CStagePerfDrumsScreen.cs
@@ -277,6 +277,7 @@ internal class CStagePerfDrumsScreen : CStagePerfCommonScreen
             {
                 eReturnValueAfterFadeOut = EPerfScreenReturnValue.StageClear;
                 ePhaseID = EPhase.PERFORMANCE_STAGE_CLEAR;
+                tStartStageClearDelay();
             }
         }
 

--- a/DTXMania/Stage/06.Performance/GuitarScreen/CStagePerfGuitarScreen.cs
+++ b/DTXMania/Stage/06.Performance/GuitarScreen/CStagePerfGuitarScreen.cs
@@ -371,6 +371,7 @@ internal partial class CStagePerfGuitarScreen : CStagePerfCommonScreen
 		{
 			eReturnValueAfterFadeOut = EPerfScreenReturnValue.StageClear;
 			ePhaseID = EPhase.PERFORMANCE_STAGE_CLEAR;
+			tStartStageClearDelay();
 		}
 		
 		ManageMixerQueue();

--- a/DTXMania/Stage/06.Performance/GuitarScreen/CStagePerfGuitarScreen.cs
+++ b/DTXMania/Stage/06.Performance/GuitarScreen/CStagePerfGuitarScreen.cs
@@ -371,7 +371,7 @@ internal partial class CStagePerfGuitarScreen : CStagePerfCommonScreen
 		{
 			eReturnValueAfterFadeOut = EPerfScreenReturnValue.StageClear;
 			ePhaseID = EPhase.PERFORMANCE_STAGE_CLEAR;
-			tStartStageClearDelay();
+			tStartResultDelay();
 		}
 		
 		ManageMixerQueue();

--- a/DTXMania/UI/Config/ConfigList.cs
+++ b/DTXMania/UI/Config/ConfigList.cs
@@ -41,6 +41,10 @@ internal class ConfigList : UIGroup
     //runs when a key-assign pad row is confirmed; the host opens the KeyAssignPanel for (part, pad, name)
     public Action<EKeyConfigPart, EKeyConfigPad, string>? onOpenKeyAssign;
 
+    public Action<(EKeyConfigPart part, EKeyConfigPad pad, string label)[]>? onOpenInputTest;
+
+    public Action? onOpenMidiTest;
+
     public ConfigList(int slotCount, int selectionIndex) : base("ConfigList")
     {
         this.selectionIndex = selectionIndex;
@@ -141,6 +145,23 @@ internal class ConfigList : UIGroup
     {
         pageStack.Push((currentItems, currentItems.Count == 0 ? 0 : Mod(currentItems.IndexOf(CurrentItem!), currentItems.Count)));
         SetItems(items);
+    }
+
+    public CItemBase? SelectNextNormal()
+    {
+        if (currentItems.Count == 0) return null;
+
+        int start = Mod(currentItems.IndexOf(CurrentItem!), currentItems.Count);
+        for (int step = 1; step <= currentItems.Count; step++)
+        {
+            int idx = Mod(start + step, currentItems.Count);
+            if (currentItems[idx].ePanelType == CItemBase.EPanelType.Normal)
+            {
+                SetItems(currentItems, idx);
+                return currentItems[idx];
+            }
+        }
+        return CurrentItem; // no other Normal item to move to
     }
 
     /// <summary>Returns to the parent page, or invokes <see cref="onExitRoot"/> at the root.</summary>

--- a/DTXMania/UI/Config/InputTestPanel.cs
+++ b/DTXMania/UI/Config/InputTestPanel.cs
@@ -1,0 +1,154 @@
+using System.Numerics;
+using DTXMania.Core;
+using DTXMania.Core.Framework;
+using DTXMania.UI.Drawable;
+using SlimDXKey = SlimDX.DirectInput.Key;
+using STKEYASSIGN = DTXMania.Core.CConfigIni.CKeyAssign.STKEYASSIGN;
+
+namespace DTXMania.UI.Config;
+
+internal sealed class InputTestPanel : UIGroup
+{
+    private const int MaxChannels = 16;
+    private const float RowSpacing = 28f;
+    private const float StartY = 56f;
+    private const float CounterX = 250f;
+    private const float LogX = 360f;
+
+    private static readonly Color4 NormalColor = Color4.White;
+    private static readonly Color4 HighlightColor = new(1f, 0.85f, 0.2f, 1f);
+
+    private readonly UIText title;
+    private readonly UIText hint;
+    private readonly UIText logHeader;
+    private readonly ScrollingLog log;
+
+    private readonly UIText[] labels = new UIText[MaxChannels];
+    private readonly UIText[] counters = new UIText[MaxChannels];
+
+    private (EKeyConfigPart part, EKeyConfigPad pad, string label)[] channels = [];
+    private readonly int[] counts = new int[MaxChannels];
+    private readonly int[] shownCounts = new int[MaxChannels];
+    private readonly bool[] shownHeld = new bool[MaxChannels];
+
+    public Action? onClose;
+    public bool IsOpen => isVisible;
+
+    public InputTestPanel() : base("InputTestPanel")
+    {
+        dontSerialize = true;
+
+        title = AddChild(new UIText("", 22f));
+
+        hint = AddChild(new UIText("", 15f));
+        hint.position = new Vector3(0, 28, 0);
+        hint.fillColor = new Color4(0.7f, 0.85f, 1f, 1f);
+
+        for (int i = 0; i < MaxChannels; i++)
+        {
+            UIText label = AddChild(new UIText("", 18f));
+            label.position = new Vector3(20, StartY + i * RowSpacing, 0);
+            label.isVisible = false;
+            labels[i] = label;
+
+            UIText counter = AddChild(new UIText("", 18f));
+            counter.position = new Vector3(CounterX, StartY + i * RowSpacing, 0);
+            counter.isVisible = false;
+            counters[i] = counter;
+        }
+
+        logHeader = AddChild(new UIText("", 15f));
+        logHeader.position = new Vector3(LogX, StartY - 24, 0);
+        logHeader.fillColor = new Color4(0.7f, 0.85f, 1f, 1f);
+
+        log = AddChild(new ScrollingLog(14));
+        log.position = new Vector3(LogX, StartY, 0);
+    }
+
+    public void Open((EKeyConfigPart part, EKeyConfigPad pad, string label)[] pads)
+    {
+        title.SetText(CDTXMania.isJapanese ? "入力テスト（全チャンネル）" : "Input Test — All Channels");
+        hint.SetText(CDTXMania.isJapanese
+            ? "各入力を押して確認します。 Esc で戻ります。"
+            : "Press your inputs to test each channel.  (Esc to return)");
+        logHeader.SetText(CDTXMania.isJapanese ? "最近の入力" : "Recent hits");
+
+        int count = Math.Min(pads.Length, MaxChannels);
+        channels = pads.Length <= MaxChannels ? pads : pads[..MaxChannels];
+
+        for (int i = 0; i < MaxChannels; i++)
+        {
+            bool used = i < count;
+            labels[i].isVisible = used;
+            counters[i].isVisible = used;
+
+            if (used)
+            {
+                labels[i].SetText(pads[i].label);
+                labels[i].fillColor = NormalColor;
+                labels[i].MarkDirty();
+                counters[i].SetText("x0");
+                counters[i].fillColor = NormalColor;
+                counters[i].MarkDirty();
+            }
+
+            counts[i] = 0;
+            shownCounts[i] = 0;
+            shownHeld[i] = false;
+        }
+
+        log.Clear();
+        isVisible = true;
+    }
+
+    public void UpdatePreview()
+    {
+        if (!isVisible) return;
+
+        for (int c = 0; c < channels.Length; c++)
+        {
+            STKEYASSIGN[] bindings = CDTXMania.ConfigIni.KeyAssign[(int)channels[c].part][(int)channels[c].pad];
+
+            bool held = false;
+            foreach (STKEYASSIGN a in bindings)
+            {
+                if (a.InputDevice == EInputDevice.Unknown) continue;
+
+                if (KeyAssignProbe.IsBindingPressed(a, pressing: true)) held = true;
+
+                if (KeyAssignProbe.IsBindingPressed(a, pressing: false))
+                {
+                    counts[c]++;
+                    log.Add($"{channels[c].label}  <-  {KeyCodeNames.FormatBinding(a)}", HighlightColor);
+                }
+            }
+
+            if (counts[c] != shownCounts[c] || held != shownHeld[c])
+            {
+                shownCounts[c] = counts[c];
+                shownHeld[c] = held;
+
+                counters[c].SetText($"x{counts[c]}");
+                counters[c].fillColor = held ? HighlightColor : NormalColor;
+                counters[c].MarkDirty();
+                labels[c].fillColor = held ? HighlightColor : NormalColor;
+                labels[c].MarkDirty();
+            }
+        }
+    }
+
+    public void PollClose()
+    {
+        if (isVisible && CDTXMania.InputManager.Keyboard.bKeyPressed((int)SlimDXKey.Escape))
+        {
+            CDTXMania.Skin.soundCancel.tPlay();
+            Close();
+        }
+    }
+
+    private void Close()
+    {
+        isVisible = false;
+        onClose?.Invoke();
+    }
+}

--- a/DTXMania/UI/Config/KeyAssignPanel.cs
+++ b/DTXMania/UI/Config/KeyAssignPanel.cs
@@ -342,7 +342,7 @@ internal sealed class KeyAssignPanel : UIGroup
             return;
         }
 
-        // live echo of whatever is currently held, before it's committed
+        //no fresh press this frame: let a stale overwrite prompt expire, then echo what's held
         if (pendingOverwrite && now > pendingDeadlineMs)
         {
             pendingOverwrite = false;

--- a/DTXMania/UI/Config/KeyAssignPanel.cs
+++ b/DTXMania/UI/Config/KeyAssignPanel.cs
@@ -476,7 +476,7 @@ internal sealed class KeyAssignPanel : UIGroup
         {
             if (i is (int)SlimDXKey.Escape or (int)SlimDXKey.UpArrow or (int)SlimDXKey.DownArrow
                 or (int)SlimDXKey.LeftArrow or (int)SlimDXKey.RightArrow or (int)SlimDXKey.Delete
-                or (int)SlimDXKey.Return)
+                or (int)SlimDXKey.Backspace or (int)SlimDXKey.Return)
             {
                 continue;
             }

--- a/DTXMania/UI/Config/KeyAssignPanel.cs
+++ b/DTXMania/UI/Config/KeyAssignPanel.cs
@@ -12,7 +12,7 @@ namespace DTXMania.UI.Config;
 /// Editor for a single pad's input bindings, shown as a stage overlay by the config stage. Replaces
 /// the old bitmap-font CActConfigKeyAssign: rows are <see cref="UIText"/>, and the host stage drives
 /// it via <see cref="MoveUp"/>/<see cref="MoveDown"/>/<see cref="Confirm"/>/<see cref="Cancel"/>/
-/// <see cref="DeleteCurrent"/> plus <see cref="PollCapture"/> each frame while waiting for input.
+/// <see cref="DeleteCurrent"/> plus <see cref="PollCapture"/>/<see cref="UpdatePreview"/> each frame.
 ///
 /// Bindings are written straight into <see cref="CConfigIni.KeyAssign"/>; the config stage persists
 /// Config.ini on exit, so nothing extra is needed here.
@@ -22,23 +22,34 @@ internal sealed class KeyAssignPanel : UIGroup
     private const int SlotCount = CConfigIni.CKeyAssign.KeyAssignsPerPad; // 16
     private const int IndexClearAll = SlotCount;      // 16
     private const int IndexReset = SlotCount + 1;     // 17
-    private const int IndexReturn = SlotCount + 2;    // 18
-    private const int RowCount = SlotCount + 3;       // 19
+    private const int IndexNext = SlotCount + 2;      // 18
+    private const int IndexReturn = SlotCount + 3;    // 19
+    private const int RowCount = SlotCount + 4;       // 20
 
     private const float RowSpacing = 24f;
     private const float SlotStartY = 40f;
     private const float FooterGap = 12f;
+    private const float PreviewColumnX = 340f;
+
+    private const int OverwriteConfirmWindowMs = 2000;
 
     private static readonly Color4 NormalColor = Color4.White;
     private static readonly Color4 HighlightColor = new(1f, 0.85f, 0.2f, 1f);
 
     private readonly UIText title;
-    private readonly UIText[] rows = new UIText[RowCount]; // 0..15 slots, then ClearAll / Reset / Return
+    private readonly UIText[] rows = new UIText[RowCount]; // 0..15 slots, then ClearAll / Reset / Next / Return
     private readonly UIText note;
 
     private readonly UIGroup overlay;
     private readonly UIText overlayPrompt;
     private readonly UIText overlayEcho;
+    private readonly UIText overlayStatus; // "already mapped, press again to overwrite" line
+
+    private readonly UIText previewHeader;
+    private readonly UIText[] previewCounters = new UIText[SlotCount];
+    private readonly int[] triggerCounts = new int[SlotCount];
+    private readonly int[] shownCounts = new int[SlotCount];
+    private readonly bool[] shownHeld = new bool[SlotCount];
 
     private EKeyConfigPart part;
     private EKeyConfigPad pad;
@@ -47,8 +58,18 @@ internal sealed class KeyAssignPanel : UIGroup
 
     private int selectedRow;
 
+    private bool pendingOverwrite;
+    private EInputDevice pendingDev;
+    private int pendingId;
+    private int pendingCode;
+    private string pendingLocation = "";
+    private long pendingDeadlineMs;
+
     /// <summary>Invoked when the user leaves the editor (Return / Cancel), to hand focus back to the list.</summary>
     public Action? onClose;
+
+    /// <summary>Invoked by the "Next Item" row to advance to the next pad without backing out to the list.</summary>
+    public Action? onNext;
 
     public bool IsOpen => isVisible;
     public bool IsWaiting { get; private set; }
@@ -71,6 +92,19 @@ internal sealed class KeyAssignPanel : UIGroup
         note.position = new Vector3(20, RowY(IndexReturn) + RowSpacing + FooterGap, 0);
         note.fillColor = new Color4(0.7f, 0.85f, 1f, 1f);
 
+        previewHeader = AddChild(new UIText(CDTXMania.isJapanese ? "入力テスト" : "Input test", 14f));
+        previewHeader.position = new Vector3(PreviewColumnX, SlotStartY - 22, 0);
+        previewHeader.fillColor = new Color4(0.7f, 0.85f, 1f, 1f);
+        previewHeader.isVisible = false;
+
+        for (int i = 0; i < SlotCount; i++)
+        {
+            UIText counter = AddChild(new UIText("", 18f));
+            counter.position = new Vector3(PreviewColumnX, RowY(i), 0);
+            counter.isVisible = false;
+            previewCounters[i] = counter;
+        }
+
         // "press an input" overlay (hidden unless waiting)
         overlay = AddChild(new UIGroup("KeyAssignOverlay"));
         overlay.position = new Vector3(20, 220, 0);
@@ -81,11 +115,14 @@ internal sealed class KeyAssignPanel : UIGroup
         overlayPrompt.fillColor = HighlightColor;
         overlayEcho = overlay.AddChild(new UIText("", 18f));
         overlayEcho.position = new Vector3(0, 32, 0);
+        overlayStatus = overlay.AddChild(new UIText("", 16f));
+        overlayStatus.position = new Vector3(0, 64, 0);
+        overlayStatus.fillColor = HighlightColor;
     }
 
     private static float RowY(int index)
     {
-        // slots are contiguous; the three footer rows sit below a small gap
+        // slots are contiguous; the footer rows sit below a small gap
         float y = SlotStartY + index * RowSpacing;
         if (index >= IndexClearAll)
         {
@@ -106,10 +143,13 @@ internal sealed class KeyAssignPanel : UIGroup
         for (int i = 0; i < SlotCount; i++)
         {
             snapshot[i] = Bindings[i];
+            triggerCounts[i] = 0; // fresh input-test counters for the new pad
         }
 
         IsWaiting = false;
+        pendingOverwrite = false;
         overlay.isVisible = false;
+        overlayStatus.SetText("");
         note.SetText("");
         selectedRow = 0;
         isVisible = true;
@@ -136,7 +176,33 @@ internal sealed class KeyAssignPanel : UIGroup
 
         rows[IndexClearAll].SetText("Clear All");
         rows[IndexReset].SetText("Reset");
+        rows[IndexNext].SetText(CDTXMania.isJapanese ? "次の項目へ >>" : "Next Item >>");
         rows[IndexReturn].SetText("<< Return to List");
+
+        RebuildPreview();
+    }
+
+    private void RebuildPreview()
+    {
+        STKEYASSIGN[] bindings = Bindings;
+        bool any = false;
+
+        for (int i = 0; i < SlotCount; i++)
+        {
+            bool assigned = bindings[i].InputDevice != EInputDevice.Unknown;
+            any |= assigned;
+
+            triggerCounts[i] = 0;
+            shownCounts[i] = 0;
+            shownHeld[i] = false;
+
+            previewCounters[i].isVisible = assigned;
+            previewCounters[i].fillColor = NormalColor;
+            previewCounters[i].SetText(assigned ? "x0" : "");
+            previewCounters[i].MarkDirty();
+        }
+
+        previewHeader.isVisible = any;
     }
 
     #region Input (called by the host stage)
@@ -165,7 +231,9 @@ internal sealed class KeyAssignPanel : UIGroup
         {
             CDTXMania.Skin.soundDecide.tPlay();
             IsWaiting = true;
+            pendingOverwrite = false;
             overlayEcho.SetText("");
+            overlayStatus.SetText("");
             overlay.isVisible = true;
             note.SetText("");
             return;
@@ -191,6 +259,11 @@ internal sealed class KeyAssignPanel : UIGroup
                 }
                 RefreshRows();
                 note.SetText(CDTXMania.isJapanese ? "元に戻しました。" : "Reset to entry state.");
+                break;
+
+            case IndexNext:
+                CDTXMania.Skin.soundDecide.tPlay();
+                onNext?.Invoke();
                 break;
 
             case IndexReturn:
@@ -226,6 +299,8 @@ internal sealed class KeyAssignPanel : UIGroup
     {
         if (!IsWaiting) return;
 
+        long now = CDTXMania.Timer.nCurrentTime;
+
         if (CDTXMania.InputManager.Keyboard.bKeyPressed((int)SlimDXKey.Escape))
         {
             StopWaiting();
@@ -235,33 +310,122 @@ internal sealed class KeyAssignPanel : UIGroup
 
         if (TryCapture(pressing: false, out EInputDevice dev, out int id, out int code))
         {
-            CommitAssignment(dev, id, code);
+            if (IsBoundToCurrentPad(dev, id, code))
+            {
+                pendingOverwrite = false;
+                string label = KeyCodeNames.FormatBinding(new STKEYASSIGN(dev, id, code));
+                overlayStatus.SetText(CDTXMania.isJapanese ? $"割り当て済み: {label}" : $"Already mapped: {label}");
+                return;
+            }
+
+            string? existing = FindExistingBinding(dev, id, code);
+
+            if (existing == null)
+            {
+                CommitAssignment(dev, id, code, null);
+                return;
+            }
+
+            bool sameAsPending = pendingOverwrite && dev == pendingDev && id == pendingId && code == pendingCode;
+            if (sameAsPending && now <= pendingDeadlineMs)
+            {
+                CommitAssignment(dev, id, code, existing);
+                return;
+            }
+
+            pendingOverwrite = true;
+            pendingDev = dev; pendingId = id; pendingCode = code;
+            pendingLocation = existing;
+            pendingDeadlineMs = now + OverwriteConfirmWindowMs;
+            CDTXMania.Skin.soundCursorMovement.tPlay();
+            UpdateOverlayStatus();
             return;
         }
 
         // live echo of whatever is currently held, before it's committed
+        if (pendingOverwrite && now > pendingDeadlineMs)
+        {
+            pendingOverwrite = false;
+            UpdateOverlayStatus();
+        }
+
         overlayEcho.SetText(TryCapture(pressing: true, out EInputDevice ed, out int eid, out int ecode)
             ? KeyCodeNames.FormatBinding(new STKEYASSIGN(ed, eid, ecode))
             : "...");
     }
 
+    public void UpdatePreview()
+    {
+        if (!isVisible || IsWaiting) return;
+
+        STKEYASSIGN[] bindings = Bindings;
+        for (int i = 0; i < SlotCount; i++)
+        {
+            STKEYASSIGN a = bindings[i];
+            if (a.InputDevice == EInputDevice.Unknown) continue;
+
+            if (KeyAssignProbe.IsBindingPressed(a, pressing: false))
+            {
+                triggerCounts[i]++;
+            }
+
+            bool held = KeyAssignProbe.IsBindingPressed(a, pressing: true);
+
+            if (triggerCounts[i] != shownCounts[i] || held != shownHeld[i])
+            {
+                shownCounts[i] = triggerCounts[i];
+                shownHeld[i] = held;
+                previewCounters[i].SetText($"x{triggerCounts[i]}");
+                previewCounters[i].fillColor = held ? HighlightColor : NormalColor;
+                previewCounters[i].MarkDirty();
+            }
+        }
+    }
+
     #endregion
 
-    private void CommitAssignment(EInputDevice dev, int id, int code)
+    private void UpdateOverlayStatus()
     {
-        string? movedFrom = FindExistingBinding(dev, id, code);
+        if (!pendingOverwrite)
+        {
+            overlayStatus.SetText("");
+            return;
+        }
 
-        // remove this input from every other binding, then set it on the selected slot (old behaviour)
+        string label = KeyCodeNames.FormatBinding(new STKEYASSIGN(pendingDev, pendingId, pendingCode));
+        overlayStatus.SetText(CDTXMania.isJapanese
+            ? $"{label} は {pendingLocation} に割り当て済み。\nもう一度押すと上書きします。"
+            : $"{label} is already mapped to {pendingLocation}.\nPress it again to overwrite.");
+    }
+
+    private void CommitAssignment(EInputDevice dev, int id, int code, string? overwritten)
+    {
+        // remove this input from every other binding, then set it on the selected slot
         CDTXMania.ConfigIni.tDeleteAlreadyAssignedInputs(dev, id, code);
         Bindings[selectedRow] = new STKEYASSIGN(dev, id, code);
 
+        pendingOverwrite = false;
         CDTXMania.Skin.soundDecide.tPlay();
         StopWaiting();
         RefreshRows();
 
-        note.SetText(movedFrom == null
+        note.SetText(overwritten == null
             ? ""
-            : (CDTXMania.isJapanese ? $"{movedFrom} から移動しました。" : $"Moved from {movedFrom}."));
+            : (CDTXMania.isJapanese ? $"{overwritten} から上書きしました。" : $"Overwrote {overwritten}."));
+    }
+
+    // Whether this exact input is already bound to any slot of the pad currently being edited.
+    private bool IsBoundToCurrentPad(EInputDevice dev, int id, int code)
+    {
+        STKEYASSIGN[] bindings = Bindings;
+        for (int s = 0; s < SlotCount; s++)
+        {
+            if (bindings[s].InputDevice == dev && bindings[s].ID == id && bindings[s].Code == code)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     // Returns a label for another pad this exact input is already bound to, or null if none.
@@ -288,7 +452,9 @@ internal sealed class KeyAssignPanel : UIGroup
     private void StopWaiting()
     {
         IsWaiting = false;
+        pendingOverwrite = false;
         overlay.isVisible = false;
+        overlayStatus.SetText("");
         // consume the press so it doesn't leak into the next frame's list input
         CDTXMania.InputManager.tPolling(CDTXMania.app.bApplicationActive, false);
     }
@@ -296,6 +462,7 @@ internal sealed class KeyAssignPanel : UIGroup
     private void Close()
     {
         IsWaiting = false;
+        pendingOverwrite = false;
         overlay.isVisible = false;
         isVisible = false;
         onClose?.Invoke();

--- a/DTXMania/UI/Config/KeyAssignProbe.cs
+++ b/DTXMania/UI/Config/KeyAssignProbe.cs
@@ -1,0 +1,40 @@
+using DTXMania.Core;
+using FDK;
+using STKEYASSIGN = DTXMania.Core.CConfigIni.CKeyAssign.STKEYASSIGN;
+
+namespace DTXMania.UI.Config;
+
+internal static class KeyAssignProbe
+{
+    public static bool Probe(IInputDevice device, int code, bool pressing) =>
+        pressing ? device.bKeyPressing(code) : device.bKeyPressed(code);
+
+    public static bool IsBindingPressed(STKEYASSIGN a, bool pressing)
+    {
+        switch (a.InputDevice)
+        {
+            case EInputDevice.Keyboard:
+                return Probe(CDTXMania.InputManager.Keyboard, a.Code, pressing);
+
+            case EInputDevice.Mouse:
+                return Probe(CDTXMania.InputManager.Mouse, a.Code, pressing);
+
+            case EInputDevice.MIDI入力:
+            case EInputDevice.Joypad:
+                EInputDeviceType wanted = a.InputDevice == EInputDevice.MIDI入力
+                    ? EInputDeviceType.MidiIn
+                    : EInputDeviceType.Joystick;
+                foreach (IInputDevice device in CDTXMania.InputManager.listInputDevices)
+                {
+                    if (device.ID == a.ID && device.eInputDeviceType == wanted)
+                    {
+                        return Probe(device, a.Code, pressing);
+                    }
+                }
+                return false;
+
+            default:
+                return false;
+        }
+    }
+}

--- a/DTXMania/UI/Config/MidiTestPanel.cs
+++ b/DTXMania/UI/Config/MidiTestPanel.cs
@@ -1,0 +1,109 @@
+using System.Numerics;
+using DTXMania.Core;
+using DTXMania.Core.Framework;
+using DTXMania.UI.Drawable;
+using FDK;
+using SlimDXKey = SlimDX.DirectInput.Key;
+using STKEYASSIGN = DTXMania.Core.CConfigIni.CKeyAssign.STKEYASSIGN;
+
+namespace DTXMania.UI.Config;
+
+internal sealed class MidiTestPanel : UIGroup
+{
+    private const int SlotCount = CConfigIni.CKeyAssign.KeyAssignsPerPad;
+
+    private static readonly Color4 MappedColor = new(0.45f, 1f, 0.45f, 1f);
+    private static readonly Color4 UnmappedColor = new(1f, 0.45f, 0.45f, 1f);
+
+    private readonly UIText title;
+    private readonly UIText hint;
+    private readonly ScrollingLog log;
+
+    public Action? onClose;
+    public bool IsOpen => isVisible;
+
+    public MidiTestPanel() : base("MidiTestPanel")
+    {
+        dontSerialize = true;
+
+        title = AddChild(new UIText("", 22f));
+
+        hint = AddChild(new UIText("", 15f));
+        hint.position = new Vector3(0, 28, 0);
+        hint.fillColor = new Color4(0.7f, 0.85f, 1f, 1f);
+
+        log = AddChild(new ScrollingLog(18));
+        log.position = new Vector3(20, 60, 0);
+    }
+
+    public void Open()
+    {
+        title.SetText(CDTXMania.isJapanese ? "MIDI テスト" : "MIDI Test");
+        hint.SetText(CDTXMania.isJapanese
+            ? "MIDI入力を押してください。緑=割り当て済み / 赤=未割り当て。 Esc で戻ります。"
+            : "Play your MIDI inputs.  green = mapped / red = unmapped.  (Esc to return)");
+        log.Clear();
+        isVisible = true;
+    }
+
+    public void UpdatePreview()
+    {
+        if (!isVisible) return;
+
+        foreach (IInputDevice device in CDTXMania.InputManager.listInputDevices)
+        {
+            if (device.eInputDeviceType != EInputDeviceType.MidiIn) continue;
+
+            for (int code = 0; code < 256; code++)
+            {
+                if (!device.bKeyPressed(code)) continue;
+
+                string midiLabel = KeyCodeNames.FormatBinding(new STKEYASSIGN(EInputDevice.MIDI入力, device.ID, code));
+                string? mapped = FindMappedPad(device.ID, code);
+
+                if (mapped != null)
+                {
+                    log.Add(CDTXMania.isJapanese ? $"{midiLabel}  ->  {mapped}" : $"{midiLabel}  ->  {mapped}", MappedColor);
+                }
+                else
+                {
+                    log.Add(CDTXMania.isJapanese ? $"{midiLabel}  (未割り当て)" : $"{midiLabel}  (unmapped)", UnmappedColor);
+                }
+            }
+        }
+    }
+
+    public void PollClose()
+    {
+        if (isVisible && CDTXMania.InputManager.Keyboard.bKeyPressed((int)SlimDXKey.Escape))
+        {
+            CDTXMania.Skin.soundCancel.tPlay();
+            Close();
+        }
+    }
+
+    private static string? FindMappedPad(int id, int code)
+    {
+        for (int p = 0; p <= (int)EKeyConfigPart.SYSTEM; p++)
+        {
+            for (int b = 0; b < (int)EKeyConfigPad.MAX; b++)
+            {
+                STKEYASSIGN[] slots = CDTXMania.ConfigIni.KeyAssign[p][b];
+                for (int s = 0; s < SlotCount; s++)
+                {
+                    if (slots[s].InputDevice == EInputDevice.MIDI入力 && slots[s].ID == id && slots[s].Code == code)
+                    {
+                        return $"{(EKeyConfigPart)p} / {(EKeyConfigPad)b}";
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void Close()
+    {
+        isVisible = false;
+        onClose?.Invoke();
+    }
+}

--- a/DTXMania/UI/Config/ScrollingLog.cs
+++ b/DTXMania/UI/Config/ScrollingLog.cs
@@ -36,13 +36,11 @@ internal sealed class ScrollingLog : UIGroup
 
     public void Add(string text, Color4 color)
     {
-        if (count == entries.Length)
-        {
-            for (int i = 1; i < count; i++) entries[i - 1] = entries[i];
-            count--;
-        }
+        // newest at the top: shift existing entries down one slot (dropping the oldest if full)
+        count = Math.Min(count + 1, entries.Length);
+        for (int i = count - 1; i > 0; i--) entries[i] = entries[i - 1];
 
-        entries[count++] = (text, color);
+        entries[0] = (text, color);
         Render();
     }
 

--- a/DTXMania/UI/Config/ScrollingLog.cs
+++ b/DTXMania/UI/Config/ScrollingLog.cs
@@ -1,0 +1,63 @@
+using System.Numerics;
+using DTXMania.Core.Framework;
+using DTXMania.UI.Drawable;
+
+namespace DTXMania.UI.Config;
+
+internal sealed class ScrollingLog : UIGroup
+{
+    private readonly UIText[] lines;
+    private readonly (string text, Color4 color)[] entries;
+    private int count;
+
+    public ScrollingLog(int visibleLines, float fontSize = 16f, float spacing = 22f) : base("ScrollingLog")
+    {
+        lines = new UIText[visibleLines];
+        entries = new (string, Color4)[visibleLines];
+
+        for (int i = 0; i < visibleLines; i++)
+        {
+            UIText line = AddChild(new UIText("", fontSize));
+            line.position = new Vector3(0, i * spacing, 0);
+            line.isVisible = false;
+            lines[i] = line;
+        }
+    }
+
+    public void Clear()
+    {
+        count = 0;
+        foreach (UIText line in lines)
+        {
+            line.isVisible = false;
+            line.SetText("");
+        }
+    }
+
+    public void Add(string text, Color4 color)
+    {
+        if (count == entries.Length)
+        {
+            for (int i = 1; i < count; i++) entries[i - 1] = entries[i];
+            count--;
+        }
+
+        entries[count++] = (text, color);
+        Render();
+    }
+
+    private void Render()
+    {
+        for (int i = 0; i < lines.Length; i++)
+        {
+            bool used = i < count;
+            lines[i].isVisible = used;
+            if (used)
+            {
+                lines[i].SetText(entries[i].text);
+                lines[i].fillColor = entries[i].color;
+            }
+            lines[i].MarkDirty();
+        }
+    }
+}


### PR DESCRIPTION
- Added new midi test option to drums key assign options
- Added input test option to all key assign options
  - Shows all mapped channels and let's you test roll through counters
- Added a "next item" button to speed up key assignment
- Added configurable stage clear delay (default setting is 2 seconds to match NX v1.4.2)
- Added configurable minimum time to show the loading screen for smoother transitions (default is 1 second)
- Changed the loading screen behaviour so the loading screen sound is no longer cut off regardless of loading time
- Changed PreSoundDelay and PreImageDelay to use the same 0.1s increment option panel added for the stage clear and loading screen delay options
- Changed default PreSoundDelay and PreImageDelay to 200ms (used to be 0)
- In Key Assign, when you press a key that was already mapped somewhere, it will now ask you to press it again before replacing the existing mapping, and it has a message when things are overwritten
- In Key Assign, pressing a key that is already mapped to the current input now does nothing instead of moving it to the new channel
  - You can remove mappings by pressing delete or backspace on an element
- Changed some descriptions in config.ini and the config stage to be more clear